### PR TITLE
Propositions de simplifications

### DIFF
--- a/src/main/java/co/simplon/prairie/FizzBuzz.java
+++ b/src/main/java/co/simplon/prairie/FizzBuzz.java
@@ -30,22 +30,17 @@ public class FizzBuzz {
     }
 
     protected String determinerCorrespondance(int entier) {
-
-            
-
-            if (entier ==0) {
+            if (entier == 0) {
                 return "0";
             }
 
-            if (entier%3 ==0) {
+            if (entier % 3 == 0) {
                 return "Fizz";
             } 
 
-            else if (entier%5 ==0) {
+            if (entier % 5 == 0) {
                 return "Buzz";
-            }   
-
-            else  
+            }
 
             return String.valueOf(entier);
              


### PR DESCRIPTION
Aération des conditionnelles (espaces autour des opérateurs), suppression du "else" qui n'est pas nécessaire du fait de l'usage de return
